### PR TITLE
chore: sync iOS and Android app versions with package.json

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -73,8 +73,9 @@ jobs:
       - name: Set CI app version
         run: |
           VERSION_OFFSET=1000
+          PKG_VERSION=$(node -p "require('./package.json').version")
           echo "CI_VERSION_CODE=$((VERSION_OFFSET + GITHUB_RUN_NUMBER))" >> "$GITHUB_ENV"
-          echo "CI_VERSION_NAME=1.0.${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
+          echo "CI_VERSION_NAME=$PKG_VERSION" >> "$GITHUB_ENV"
 
       - name: Set up JDK
         uses: actions/setup-java@v4
@@ -120,3 +121,16 @@ jobs:
         with:
           name: app-release-aab-${{ env.CI_VERSION_NAME }}
           path: android/app/build/outputs/bundle/release/app-release.aab
+
+      # Google Play 배포
+      - name: Deploy to Google Play (Internal Testing)
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonRaw: ${{ secrets.SERVICE_ACCOUNT_JSON }}
+          packageName: com.ddakjihostapp
+          releaseFiles: android/app/build/outputs/bundle/release/app-release.aab
+          # TestFlight와 같은 역할을 하는 '내부 테스트' 트랙
+          track: internal  
+          status: completed 
+          # 필요하다면 출시 노트를 작성할 수 있습니다.
+          whatsNewDirectory: android/release-notes

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -40,7 +40,12 @@ platform :ios do
     UI.message("🚀 Build scheme: #{scheme_name}")
     UI.message("🌐 API_BASE_URL: #{ENV['API_BASE_URL']}")
 
-    increment_version_number(version_number: "1.0.0")
+    require 'json'
+    package_path = File.join(__dir__, "..", "..", "package.json")
+    package = JSON.parse(File.read(package_path))
+    app_version = package["version"]
+
+    increment_version_number(version_number: app_version)
     increment_build_number(build_number: Time.now.strftime("%Y%m%d%H%M"))
 
     match(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ddakjiHostApp",
-  "version": "0.0.1",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
[빌드설정] 앱 버전 관리를 package.json 기준으로 통일
- 버전을 번거롭게 따로 올리지 않도록 양대 OS 모두 package.json을 읽어 배포되도록 수정