### PR TITLE
ci: enable Google Play auto-deployment for internal track

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -122,15 +122,15 @@ jobs:
           name: app-release-aab-${{ env.CI_VERSION_NAME }}
           path: android/app/build/outputs/bundle/release/app-release.aab
 
-      # # Google Play 배포
-      # - name: Deploy to Google Play (Internal Testing)
-      #   uses: r0adkll/upload-google-play@v1
-      #   with:
-      #     serviceAccountJsonRaw: ${{ secrets.SERVICE_ACCOUNT_JSON }}
-      #     packageName: com.ddakjihostapp
-      #     releaseFiles: android/app/build/outputs/bundle/release/app-release.aab
-      #     # TestFlight와 같은 역할을 하는 '내부 테스트' 트랙
-      #     track: internal  
-      #     status: completed 
-      #     # 필요하다면 출시 노트를 작성할 수 있습니다.
-      #     whatsNewDirectory: android/release-notes
+      # Google Play 배포
+      - name: Deploy to Google Play (Internal Testing)
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonRaw: ${{ secrets.SERVICE_ACCOUNT_JSON }}
+          packageName: com.ddakjihostapp
+          releaseFiles: android/app/build/outputs/bundle/release/app-release.aab
+          # TestFlight와 같은 역할을 하는 '내부 테스트' 트랙
+          track: internal  
+          status: completed 
+          # 필요하다면 출시 노트를 작성할 수 있습니다. (폴더가 없으면 에러가 날 수 있어 주석 유지)
+          # whatsNewDirectory: android/release-notes


### PR DESCRIPTION
구글 플레이 내부 테스트 자동 배포 기능 활성화
Google Cloud 에서 발급한 서비스 계정 키를 통해 플레이 콘솔에 앱이 자동 배포되도록 설정